### PR TITLE
README: Fixed the C and C# links in the 'Contents' section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
  - [Java](#java)
  - [C#](#c-1)
  - [CSS](#css)
- - [C](undefined)
+ - [C](#c-1)
  - [C++](#c-2)
  - [ActionScript](#actionscript)
  - [Clojure](#clojure)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
  - [JavaScript](#javascript)
  - [Java](#java)
- - [C#](#c-1)
+ - [C#](#c)
  - [CSS](#css)
  - [C](#c-1)
  - [C++](#c-2)


### PR DESCRIPTION
The `C` link was undefined and the `C#` pointed at the `C` section.

This PR tries to fix this